### PR TITLE
Typo on the file_line parameter match_for_absence

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ define advanced_audit_policy (
       ensure            => $ensure,
       path              => $audit_csv_file_path,
       match             => "^,System,${policy},${policy_guid},",
-      match_for_absense => true,
+      match_for_absence => true,
     }
   }
 


### PR DESCRIPTION
https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/lib/puppet/type/file_line.rb#L118

Produces the error `Error: no parameter named 'match_for_absense'`